### PR TITLE
View your downloaded records link

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id "com.gorylenko.gradle-git-properties" version "1.4.17"
 }
 
-version "2.1.4"
+version "2.2.0-SNAPSHOT"
 group "au.org.ala"
 
 apply plugin:"eclipse"

--- a/grails-app/views/profile/myprofile.gsp
+++ b/grails-app/views/profile/myprofile.gsp
@@ -39,7 +39,7 @@
                 </a>
             </li>
             <li>
-                <a href="${grailsApplication.config.biocache.search.url}?%22${user.id}%22">
+                <a href="${grailsApplication.config.biocache.search.url}%22${user.id}%22">
                     View records you have annotated
                 </a>
             </li>

--- a/grails-app/views/profile/myprofile.gsp
+++ b/grails-app/views/profile/myprofile.gsp
@@ -39,8 +39,13 @@
                 </a>
             </li>
             <li>
-                <a href="${grailsApplication.config.biocache.search.url}?q=*%3A*&fq=assertion_user_id%3A%22${user.id}%22">
+                <a href="${grailsApplication.config.biocache.search.url}?%22${user.id}%22">
                     View records you have annotated
+                </a>
+            </li>
+            <li>
+                <a href="${grailsApplication.config.biocache.myDownloads.url}">
+                    View your downloaded records
                 </a>
             </li>
             <li>


### PR DESCRIPTION
Currently deployed to https://auth-test.ala.org.au/userdetails/myprofile

Link to View your downloaded records will work as long as you manually point biocache.ala.org.au to biocache-clustered in your /etc/hosts

Currently the following (if this fails, run ``dig biocache-clustered.ala.org.au`` to find the correct IP addresses for the load balancer):

```
54.66.158.37 biocache.ala.org.au
13.55.7.11 biocache.ala.org.au
``` 

