### PR TITLE
Improve delete account messages

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -167,7 +167,8 @@ user.list.actions=Actions
 userdetails.my.profile=My profile
 flickr.fail.link.failed=Flickr account link failed
 flickr.fail.description=We were unable to link to your Flickr account. If this problem persists, please email <a href="mailto:{0}">{0}</a>
-default.button.delete.user.confirm.message: "Are you sure want to disable your account? You won't be able to login again. You will have to contact support@ala.org.au in the future if you want to reactivate your account."
+default.button.delete.user.confirm.message=Are you sure want to disable your account? You won't be able to login again. You will have to contact us in the future if you want to reactivate your account.
+default.button.edit.delete.user.confirm.message=Are you sure want to delete this user? This may have serious implications if the user has used systems. Their information may need to be purged from other systems.
 inaturalist.fail.link=iNaturalist account link failed
 inaturalist.fail.description=We were unable to link to your iNaturalist account. If this problem persists, please email <a href="mailto:{0}">{0}</a>
 myprofile.hello=Hello {0} !

--- a/grails-app/views/registration/createAccount.gsp
+++ b/grails-app/views/registration/createAccount.gsp
@@ -214,7 +214,7 @@
 
             $("#disableAccountSubmit").attr('disabled','disabled');
 
-            var valid = confirm("${g.message(code: 'default.button.delete.user.confirm.message', default: 'Are you sure want to disable your account? You won\'t be able to login again. You will have to contact us in the future if you want to reactivate your account.')}");
+            var valid = confirm("${message(code: 'default.button.delete.user.confirm.message', default: 'Are you sure want to disable your account? You won\'t be able to login again. You will have to contact us in the future if you want to reactivate your account.')}");
 
             if (valid) {
                 $('#updateAccountForm').validationEngine('detach');

--- a/grails-app/views/registration/createAccount.gsp
+++ b/grails-app/views/registration/createAccount.gsp
@@ -214,7 +214,8 @@
 
             $("#disableAccountSubmit").attr('disabled','disabled');
 
-            var valid = confirm(${message(code: 'default.button.delete.user.confirm.message', default: "Are you sure want to disable your account? You won't be able to login again. You will have to contact support@ala.org.au in the future if you want to reactivate your account.")});
+            var valid = confirm("${g.message(code: 'default.button.delete.user.confirm.message',
+                                default: 'Are you sure want to disable your account? You won\'t be able to login again. You will have to contact us in the future if you want to reactivate your account.')}");
 
             if (valid) {
                 $('#updateAccountForm').validationEngine('detach');

--- a/grails-app/views/registration/createAccount.gsp
+++ b/grails-app/views/registration/createAccount.gsp
@@ -214,8 +214,7 @@
 
             $("#disableAccountSubmit").attr('disabled','disabled');
 
-            var valid = confirm("${g.message(code: 'default.button.delete.user.confirm.message',
-                                default: 'Are you sure want to disable your account? You won\'t be able to login again. You will have to contact us in the future if you want to reactivate your account.')}");
+            var valid = confirm("${g.message(code: 'default.button.delete.user.confirm.message', default: 'Are you sure want to disable your account? You won\'t be able to login again. You will have to contact us in the future if you want to reactivate your account.')}");
 
             if (valid) {
                 $('#updateAccountForm').validationEngine('detach');

--- a/grails-app/views/user/edit.gsp
+++ b/grails-app/views/user/edit.gsp
@@ -38,7 +38,7 @@
                                     value="${message(code: 'default.button.update.label', default: 'Update')}"/>
                     <g:actionSubmit class="btn btn-danger" action="delete"
                                     value="${message(code: 'default.button.delete.label', default: 'Delete')}" formnovalidate=""
-                                    onclick="return confirm('${message(code: 'default.button.delete.user.confirm.message', default: 'Are you sure want to delete this user? This may have serious implications if the user has used systems. Their information may need to be purged from other systems.')}');"/>
+                                    onclick="return confirm('${message(code: 'default.button.edit.delete.user.confirm.message', default: 'Are you sure want to delete this user? This may have serious implications if the user has used systems. Their information may need to be purged from other systems.')}');"/>
                 </fieldset>
             </g:form>
         </div>


### PR DESCRIPTION
Improve of delete/disable account messages, following Nick [comment](https://github.com/AtlasOfLivingAustralia/userdetails/commit/47026d0b3204c9a900bd297930338a99a95d8a0f#commitcomment-44976358).

I also restored the user account disable message from the default value.