### PR TITLE
Extract password operations and other cleanup

### DIFF
--- a/userdetails-cognito/build.gradle
+++ b/userdetails-cognito/build.gradle
@@ -103,15 +103,6 @@ dependencies {
     // Base userdetails plugin
     implementation project(':userdetails-plugin')
 
-    // transitive dependencies aren't available from plugin
-//    implementation "org.grails.plugins:ala-bootstrap3:4.1.0"
-//    implementation "org.grails.plugins:ala-ws-plugin:3.1.1"
-//    implementation "org.grails.plugins:ala-ws-security-plugin:4.3.3-SNAPSHOT"
-//    implementation "org.grails.plugins:ala-auth:5.1.1"
-//    implementation "org.grails.plugins:ala-admin-plugin:2.3.0"
-//
-//    implementation 'org.grails.plugins:mail:3.0.0'
-
     // regular JAR dependencies
 
     implementation 'com.amazonaws:aws-java-sdk-cognitoidentity:1.12.279'

--- a/userdetails-cognito/grails-app/conf/application.yml
+++ b/userdetails-cognito/grails-app/conf/application.yml
@@ -5,6 +5,7 @@ grails:
         defaultPackage: au.org.ala.userdetails.cognito
     config:
         locations:
+            - file:/data/userdetails/config/userdetails-cognito-config.yml
             - file:/data/userdetails/config/userdetails-config.properties
             - file:/data/userdetails/config/userdetails-config.yml
             - file:/data/userdetails/config/userdetails-config.groovy

--- a/userdetails-cognito/grails-app/init/au/org/ala/userdetails/cognito/Application.groovy
+++ b/userdetails-cognito/grails-app/init/au/org/ala/userdetails/cognito/Application.groovy
@@ -82,4 +82,8 @@ class Application extends GrailsAutoConfiguration {
         return userService
     }
 
+    @Bean('passwordOperations')
+    IPasswordOperations passwordOperations() {
+        new CognitoPasswordOperations()
+    }
 }

--- a/userdetails-cognito/src/main/groovy/au/org/ala/userdetails/CognitoPasswordOperations.groovy
+++ b/userdetails-cognito/src/main/groovy/au/org/ala/userdetails/CognitoPasswordOperations.groovy
@@ -1,0 +1,79 @@
+package au.org.ala.userdetails
+
+import au.org.ala.auth.PasswordResetFailedException
+import au.org.ala.users.UserRecord
+import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider
+import com.amazonaws.services.cognitoidp.model.AdminResetUserPasswordRequest
+import com.amazonaws.services.cognitoidp.model.AdminSetUserPasswordRequest
+import com.amazonaws.services.cognitoidp.model.ConfirmForgotPasswordRequest
+import grails.core.GrailsApplication
+import org.apache.commons.codec.digest.HmacAlgorithms
+import org.apache.commons.codec.digest.HmacUtils
+
+class CognitoPasswordOperations implements IPasswordOperations {
+
+    GrailsApplication grailsApplication
+
+    AWSCognitoIdentityProvider cognitoIdp
+    String poolId
+
+    @Override
+    boolean resetPassword(UserRecord user, String newPassword, boolean isPermanent, String confirmationCode) {
+        if(!user || !newPassword) {
+            return false
+        }
+
+        try {
+            if (confirmationCode == null) {
+                def request = new AdminSetUserPasswordRequest()
+                request.username = user.email
+                request.userPoolId = poolId
+                request.password = newPassword
+                request.permanent = isPermanent
+
+                def response = cognitoIdp.adminSetUserPassword(request)
+                return response.getSdkHttpMetadata().httpStatusCode == 200
+            } else {
+                def request = new ConfirmForgotPasswordRequest().withUsername(user.email)
+                request.password = newPassword
+                request.confirmationCode = confirmationCode
+                request.clientId = grailsApplication.config.getProperty('security.oidc.client-id')
+                request.secretHash = calculateSecretHash(grailsApplication.config.getProperty('security.oidc.client-id'),
+                        grailsApplication.config.getProperty('security.oidc.secret'), user.email)
+                def response = cognitoIdp.confirmForgotPassword(request)
+                return response.getSdkHttpMetadata().httpStatusCode == 200
+            }
+        } catch(Exception e) {
+            return false
+        }
+    }
+
+    @Override
+    void resetAndSendTemporaryPassword(UserRecord user, String emailSubject, String emailTitle, String emailBody, String password) throws PasswordResetFailedException {
+        def request = new AdminResetUserPasswordRequest()
+        request.username = user.email
+        request.userPoolId = poolId
+
+        cognitoIdp.adminResetUserPassword(request)
+    }
+
+    static String calculateSecretHash(String userPoolClientId, String userPoolClientSecret, String userName) {
+        try {
+            byte[] rawHmac = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, userPoolClientSecret).hmac("$userName$userPoolClientId")
+            return Base64.getEncoder().encodeToString(rawHmac)
+        } catch (Exception e) {
+            throw new RuntimeException("Error while calculating ")
+        }
+    }
+
+    @Override
+    String getResetPasswordUrl(UserRecord user) {
+        return null
+    }
+
+    @Override
+    String getPasswordResetView() {
+        return "passwordResetCognito"
+    }
+
+}

--- a/userdetails-gorm/build.gradle
+++ b/userdetails-gorm/build.gradle
@@ -105,26 +105,6 @@ dependencies {
 
     // Grails plugin dependencies
 
-    implementation "org.grails.plugins:ala-bootstrap3:4.1.0"
-    implementation "org.grails.plugins:ala-ws-plugin:3.1.1"
-    implementation "org.grails.plugins:ala-ws-security-plugin:4.3.3-SNAPSHOT"
-    implementation "org.grails.plugins:ala-auth:5.2.0-CognitoLogoutFix-SNAPSHOT"
-    implementation "org.grails.plugins:ala-admin-plugin:2.3.0"
-
-    implementation 'dk.glasius:external-config:3.1.0'
-    implementation 'org.grails.plugins:http-builder-helper:1.1.0'
-    implementation "org.grails.plugins:csv:1.0.1"
-    implementation 'org.grails.plugins:mail:3.0.0'
-
-    implementation "org.grails.plugins:oauth:4.0.0"
-    // transitive oauth plugin deps used in code
-    implementation "com.github.scribejava:scribejava-core:4.0.0"
-    implementation "com.github.scribejava:scribejava-apis:4.0.0"
-
-    implementation "domurtag.plugins:grails-simple-captcha:1.0.0-grails3"
-    implementation "org.grails.plugins:export:2.0.0"
-    implementation 'org.grails.plugins:grails-markdown:3.0.0'
-
     // Base Userdetails plugin
     implementation project(':userdetails-plugin')
 

--- a/userdetails-gorm/grails-app/conf/application.yml
+++ b/userdetails-gorm/grails-app/conf/application.yml
@@ -5,6 +5,7 @@ grails:
         defaultPackage: au.org.ala.userdetails.gorm
     config:
         locations:
+            - file:/data/userdetails/config/userdetails-gorm-config.yml
             - file:/data/userdetails/config/userdetails-config.properties
             - file:/data/userdetails/config/userdetails-config.yml
             - file:/data/userdetails/config/userdetails-config.groovy
@@ -131,6 +132,26 @@ security:
     allowUnsignedIdTokens: true # Disable once CAS no longer suggests the none algorithm
   jwt:
     fallbackToLegacyBehaviour: true # Reset to false once legacy api keys no longer supported
+
+password:
+  encoder: bcrypt # or legacy
+  generatedLength: 10
+  # Passwords must satisfy this policy.
+  # The minLength policy is always required, even when the policy is disabled. It has a default value of 8.
+  # To remove / disable an aspect of the policy, either remove the item or set to 0 / false, whichever is relevant.
+  policy:
+    enabled: false # default to match previous version, override in external config
+#    minLength: 8
+#    maxLength: 64
+#    excludeUsername: false
+#    excludeUsQwertyKeyboardSequence: false
+#    excludeCommonPasswords: false
+#    charGroupMinRequired: 0
+#    charGroupMinUpperCase: 0
+#    charGroupMinLowerCase: 0
+#    charGroupMinUpperOrLowerCase: 0
+#    charGroupMinDigit: 0
+#    charGroupMinSpecial: 0
 
 openapi:
   title: UserDetails REST services

--- a/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/AuthorisedSystem.groovy
+++ b/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/AuthorisedSystem.groovy
@@ -15,11 +15,7 @@
 
 package au.org.ala.userdetails.gorm
 
-import grails.web.databinding.WebDataBinding
-import groovy.transform.EqualsAndHashCode
-
-@EqualsAndHashCode(includes = 'id')
-class AuthorisedSystem implements WebDataBinding, Serializable {
+class AuthorisedSystem {
 
     String host
     String description

--- a/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/User.groovy
+++ b/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/User.groovy
@@ -20,15 +20,13 @@ import groovy.transform.EqualsAndHashCode
 
 import java.sql.Timestamp
 
-@EqualsAndHashCode(includes = 'id')
+@EqualsAndHashCode
 class User extends UserRecord<Long> implements Serializable {
 
     static hasMany =  [
             userRoles: UserRole,
             userProperties: UserProperty
     ]
-
-    String userId
 
     String firstName
     String lastName
@@ -48,14 +46,13 @@ class User extends UserRecord<Long> implements Serializable {
 
     String displayName
 
-    Collection<UserRole> userRoles
-    Collection<UserProperty> userProperties
+//    Collection<UserRole> userRoles
+//    Collection<UserProperty> userProperties
 
     static mapping = {
         table 'users'
 
         id (generator:'identity', column:'userid', type:'long')
-        userId column:'userid', updatable: false, insertable: false, type: 'string'
 
         userName column:  'username'
         firstName column:  'firstname'
@@ -76,6 +73,11 @@ class User extends UserRecord<Long> implements Serializable {
         lastLogin nullable: true
         tempAuthKey nullable: true
         displayName nullable: true
+    }
+
+    @Override
+    String getUserId() {
+        return this.id?.toString()
     }
 
     static List<String[]> findNameAndEmailWhereEmailIsNotNull() {

--- a/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/UserProperty.groovy
+++ b/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/UserProperty.groovy
@@ -19,7 +19,6 @@ import au.org.ala.users.UserPropertyRecord
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import groovy.transform.EqualsAndHashCode
 
-@EqualsAndHashCode(includes = 'id')
 @JsonIgnoreProperties(['metaClass','errors'])
 class UserProperty extends UserPropertyRecord implements Serializable {
 

--- a/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/UserRole.groovy
+++ b/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/UserRole.groovy
@@ -18,7 +18,6 @@ package au.org.ala.userdetails.gorm
 import au.org.ala.users.UserRoleRecord
 import groovy.transform.EqualsAndHashCode
 
-@EqualsAndHashCode(includes = 'id')
 class UserRole extends UserRoleRecord implements Serializable {
 
     User user

--- a/userdetails-gorm/grails-app/init/au/org/ala/userdetails/gorm/Application.groovy
+++ b/userdetails-gorm/grails-app/init/au/org/ala/userdetails/gorm/Application.groovy
@@ -17,6 +17,7 @@ package au.org.ala.userdetails.gorm
 
 import au.org.ala.userdetails.EmailService
 import au.org.ala.userdetails.IAuthorisedSystemRepository
+import au.org.ala.userdetails.IPasswordOperations
 import au.org.ala.userdetails.IUserService
 import au.org.ala.userdetails.LocationService
 import au.org.ala.userdetails.PasswordService
@@ -77,4 +78,8 @@ class Application extends GrailsAutoConfiguration {
         new GormAuthorisedSystemRepository()
     }
 
+    @Bean('passwordOperations')
+    IPasswordOperations passwordOperations() {
+        new GormPasswordOperations()
+    }
 }

--- a/userdetails-gorm/src/main/groovy/au/org/ala/userdetails/gorm/GormPasswordOperations.groovy
+++ b/userdetails-gorm/src/main/groovy/au/org/ala/userdetails/gorm/GormPasswordOperations.groovy
@@ -3,6 +3,7 @@ package au.org.ala.userdetails.gorm
 import au.org.ala.auth.PasswordResetFailedException
 import au.org.ala.cas.encoding.BcryptPasswordEncoder
 import au.org.ala.cas.encoding.LegacyPasswordEncoder
+import au.org.ala.cas.encoding.PasswordEncoder
 import au.org.ala.userdetails.EmailService
 import au.org.ala.userdetails.IPasswordOperations
 import au.org.ala.users.UserRecord
@@ -13,6 +14,9 @@ class GormPasswordOperations implements IPasswordOperations {
 
     static final String BCRYPT_ENCODER_TYPE = 'bcrypt'
     static final String LEGACY_ENCODER_TYPE = 'legacy'
+
+    static final String STATUS_CURRENT = 'CURRENT'
+
 
     @Value('${password.encoder}')
     String passwordEncoderType = 'bcrypt'
@@ -76,4 +80,58 @@ class GormPasswordOperations implements IPasswordOperations {
         return "startPasswordReset"
     }
 
+    /**
+     * Check that a plain-text password matches a user's existing password.
+     * @param user The user.
+     * @param password The plain-text password to match.
+     * @return True if the password matches the existing password, otherwise false.
+     */
+    boolean checkUserPassword(UserRecord user, String password) {
+        assert user instanceof User
+        if (!password || password.size() < 1) {
+            throw new IllegalArgumentException("The password must not be empty.")
+        }
+        if (user == null) {
+            throw new IllegalArgumentException("Must provide the user to compare a password.")
+        }
+
+        def passwordType = getPasswordType()
+        def passwordStatus = STATUS_CURRENT
+        def existingPasswords = Password.findAllByUserAndTypeAndStatus(user, passwordType, passwordStatus)
+
+        def dateTimeNow = new Date().toTimestamp()
+
+        def matchingPassword = existingPasswords.find { item ->
+            comparePasswords(password, item.password) && (item.expiry == null || item.expiry > dateTimeNow)
+        }
+
+        return matchingPassword
+    }
+
+    /**
+     * Compare a plain-text password to an encoded password.
+     * @param plainPassword The plain-text password.
+     * @param hashedPassword The encoded password.
+     * @return True if the passwords match, otherwise false.
+     */
+    Boolean comparePasswords(String plainPassword, String hashedPassword) {
+        if (!plainPassword || plainPassword.length() < 1 || !hashedPassword || hashedPassword.length() < 1) {
+            throw new IllegalArgumentException("Must supply a plain text password and a hashed password to be compared.")
+        }
+
+        def encoder = getEncoder()
+        def encodedPassword = encoder.matches(plainPassword, hashedPassword)
+        return encodedPassword
+    }
+
+    private PasswordEncoder getEncoder() {
+        def encoder = passwordEncoderType.equalsIgnoreCase(BCRYPT_ENCODER_TYPE) ?
+                new BcryptPasswordEncoder(bcryptStrength) :
+                new LegacyPasswordEncoder(legacySalt, legacyAlgorithm, true)
+        return encoder
+    }
+
+    private getPasswordType() {
+        return passwordEncoderType.equalsIgnoreCase(BCRYPT_ENCODER_TYPE) ? BCRYPT_ENCODER_TYPE : LEGACY_ENCODER_TYPE
+    }
 }

--- a/userdetails-gorm/src/main/groovy/au/org/ala/userdetails/gorm/GormPasswordOperations.groovy
+++ b/userdetails-gorm/src/main/groovy/au/org/ala/userdetails/gorm/GormPasswordOperations.groovy
@@ -1,0 +1,79 @@
+package au.org.ala.userdetails.gorm
+
+import au.org.ala.auth.PasswordResetFailedException
+import au.org.ala.cas.encoding.BcryptPasswordEncoder
+import au.org.ala.cas.encoding.LegacyPasswordEncoder
+import au.org.ala.userdetails.EmailService
+import au.org.ala.userdetails.IPasswordOperations
+import au.org.ala.users.UserRecord
+import grails.gorm.transactions.NotTransactional
+import org.springframework.beans.factory.annotation.Value
+
+class GormPasswordOperations implements IPasswordOperations {
+
+    static final String BCRYPT_ENCODER_TYPE = 'bcrypt'
+    static final String LEGACY_ENCODER_TYPE = 'legacy'
+
+    @Value('${password.encoder}')
+    String passwordEncoderType = 'bcrypt'
+    @Value('${bcrypt.strength}')
+    Integer bcryptStrength = 10
+    @Value('${encoding.algorithm}')
+    String legacyAlgorithm
+    @Value('${encoding.salt}')
+    String legacySalt
+
+    EmailService emailService
+
+    @Override
+    boolean resetPassword(UserRecord user, String newPassword, boolean isPermanent, String confirmationCode) {
+        assert user instanceof User
+        Password.findAllByUser(user).each {
+            it.delete()
+        }
+
+        boolean isBcrypt = passwordEncoderType.equalsIgnoreCase(BCRYPT_ENCODER_TYPE)
+
+        def encoder = isBcrypt ? new BcryptPasswordEncoder(bcryptStrength) : new LegacyPasswordEncoder(legacySalt, legacyAlgorithm, true)
+        def encodedPassword = encoder.encode(newPassword)
+
+        //reuse object if old password
+        def password = new Password()
+        password.user = user
+        password.password = encodedPassword
+        password.type = isBcrypt ? BCRYPT_ENCODER_TYPE : LEGACY_ENCODER_TYPE
+        password.created = new Date().toTimestamp()
+        password.expiry = null
+        password.status = "CURRENT"
+        password.save(failOnError: true)
+        return true
+    }
+
+
+    @Override
+    void resetAndSendTemporaryPassword(UserRecord user, String emailSubject, String emailTitle, String emailBody, String password = null) throws PasswordResetFailedException {
+        assert user instanceof User
+        if (user) {
+            //set the temp auth key
+            user.tempAuthKey = UUID.randomUUID().toString()
+            user.save(flush: true)
+            //send the email
+            emailService.sendPasswordReset(user, user.tempAuthKey, emailSubject, emailTitle, emailBody, password)
+        }
+    }
+
+    @NotTransactional
+    @Override
+    String getResetPasswordUrl(UserRecord user) {
+        assert user instanceof User
+        if(user.tempAuthKey){
+            emailService.getServerUrl() + "resetPassword/" +  user.id +  "/"  + user.tempAuthKey
+        }
+    }
+
+    @Override
+    String getPasswordResetView() {
+        return "startPasswordReset"
+    }
+
+}

--- a/userdetails-plugin/build.gradle
+++ b/userdetails-plugin/build.gradle
@@ -113,7 +113,7 @@ dependencies {
     api "org.grails.plugins:ala-bootstrap3:4.1.0"
     api "org.grails.plugins:ala-ws-plugin:3.1.1"
     api "org.grails.plugins:ala-ws-security-plugin:4.3.3-SNAPSHOT"
-    api "org.grails.plugins:ala-auth:5.1.1"
+    api "org.grails.plugins:ala-auth:5.2.0-SNAPSHOT"
     api "org.grails.plugins:ala-admin-plugin:2.3.0"
 
     api 'dk.glasius:external-config:3.1.0'

--- a/userdetails-plugin/grails-app/conf/plugin.yml
+++ b/userdetails-plugin/grails-app/conf/plugin.yml
@@ -209,6 +209,7 @@ userdetails:
     authorisedSystems: false
     bulkCreate: false
     exportUsers: false
+    requirePasswordForUserUpdate: false # can't be applied to users who have signed in with delegated authentication, so disabled for now
 
 attributes:
     states:

--- a/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/RegistrationController.groovy
+++ b/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/RegistrationController.groovy
@@ -92,7 +92,7 @@ class RegistrationController {
                 if (user.tempAuthKey == cmd.authKey) {
                     //update the password
                     try {
-                        userService.resetPassword(user, cmd.password, true, null)
+                        passwordService.resetPassword(user, cmd.password, true, null)
                         userService.clearTempAuthKey(user)
                         redirect(controller: 'registration', action: 'passwordResetSuccess')
                         log.info("Password successfully reset for user: " + cmd.userId)
@@ -125,7 +125,7 @@ class RegistrationController {
                 }
                 //update the password
                 try {
-                    def success = userService.resetPassword(user, cmd.password, true, cmd.code)
+                    def success = passwordService.resetPassword(user, cmd.password, true, cmd.code)
                     if(success) {
                         Map resp = webService.get("${grailsApplication.config.getProperty('grails.serverURL')}/logout?")
                         redirect(controller: 'registration', action: 'passwordResetSuccess')
@@ -189,8 +189,8 @@ class RegistrationController {
         def user = userService.getUserById(params.email)
         if (user) {
             try {
-                userService.resetAndSendTemporaryPassword(user, null, null, null, null)
-                render(view: userService.getPasswordResetView(), model: [email: params.email])
+                passwordService.resetAndSendTemporaryPassword(user, null, null, null, null)
+                render(view: passwordService.getPasswordResetView(), model: [email: params.email])
             } catch (Exception e) {
                 log.error("Problem starting password reset for email address: " + params.email)
                 log.error(e.getMessage(), e)
@@ -304,10 +304,10 @@ class RegistrationController {
                     //does a user with the supplied email address exist
                     def user = userService.registerUser(params)
 
-                    if(user) {
+                    if (user) {
                         //store the password
                         try {
-                            userService.resetPassword(user, params.password, true, null)
+                            passwordService.resetPassword(user, params.password, true, null)
                             //store the password
                             userService.sendAccountActivation(user)
                             redirect(action: 'accountCreated', id: user.id)
@@ -315,8 +315,7 @@ class RegistrationController {
                             log.error("Couldn't reset password", e)
                             render(view: "accountError", model: [msg: "Failed to reset password"])
                         }
-                    }
-                    else{
+                    } else {
                         log.error('Couldn\'t create user')
                         render(view: "accountError", model: [msg: 'Couldn\'t create user'])
                     }

--- a/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/UserController.groovy
+++ b/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/UserController.groovy
@@ -27,6 +27,8 @@ class UserController {
 
     static allowedMethods = [save: "POST", update: "POST", delete: "POST"]
 
+    def passwordService
+
     @Autowired
     @Qualifier('userService')
     IUserService userService
@@ -83,7 +85,7 @@ class UserController {
             return
         }
 
-        String resetPasswordUrl = userService.getResetPasswordUrl(userInstance)
+        String resetPasswordUrl = passwordService.getResetPasswordUrl(userInstance)
 
         [userInstance: userInstance, resetPasswordUrl: resetPasswordUrl]
     }

--- a/userdetails-plugin/grails-app/services/au/org/ala/userdetails/PasswordService.groovy
+++ b/userdetails-plugin/grails-app/services/au/org/ala/userdetails/PasswordService.groovy
@@ -53,8 +53,6 @@ class PasswordService {
     static final String BCRYPT_ENCODER_TYPE = 'bcrypt'
     static final String LEGACY_ENCODER_TYPE = 'legacy'
 
-    static final String STATUS_CURRENT = 'CURRENT'
-
     private PasswordValidator builtPasswordValidator = null
     private PasswordPolicy builtPasswordPolicy = null
     private List<Rule> builtPasswordGeneralRules = null
@@ -105,26 +103,7 @@ class PasswordService {
      * @return True if the password matches the existing password, otherwise false.
      */
     boolean checkUserPassword(UserRecord user, String password) {
-        if (!password || password.size() < 1) {
-            throw new IllegalArgumentException("The password must not be empty.")
-        }
-        if (user == null) {
-            throw new IllegalArgumentException("Must provide the user to compare a password.")
-        }
-
-        def passwordType = getPasswordType()
-        def passwordStatus = STATUS_CURRENT
-        // TODO Port to userservice
-//        def existingPasswords = Password.findAllByUserAndTypeAndStatus(user, passwordType, passwordStatus)
-
-        def dateTimeNow = new Date().toTimestamp()
-        // TODO Port to userservice
-        def matchPassword = false
-//        def matchingPassword = existingPasswords.find { item ->
-//            comparePasswords(password, item.password) && (item.expiry == null || item.expiry > dateTimeNow)
-//        }
-
-        return matchingPassword
+        return passwordOperations.checkUserPassword(user, password)
     }
 
     /**
@@ -139,22 +118,6 @@ class PasswordService {
 
         def encoder = getEncoder()
         def encodedPassword = encoder.encode(password)
-        return encodedPassword
-    }
-
-    /**
-     * Compare a plain-text password to an encoded password.
-     * @param plainPassword The plain-text password.
-     * @param hashedPassword The encoded password.
-     * @return True if the passwords match, otherwise false.
-     */
-    Boolean comparePasswords(String plainPassword, String hashedPassword) {
-        if (!plainPassword || plainPassword.length() < 1 || !hashedPassword || hashedPassword.length() < 1) {
-            throw new IllegalArgumentException("Must supply a plain text password and a hashed password to be compared.")
-        }
-
-        def encoder = getEncoder()
-        def encodedPassword = encoder.matches(plainPassword, hashedPassword)
         return encodedPassword
     }
 
@@ -341,16 +304,5 @@ class PasswordService {
         }
 
         return this.builtPasswordGeneralRules
-    }
-
-    private PasswordEncoder getEncoder() {
-        def encoder = passwordEncoderType.equalsIgnoreCase(BCRYPT_ENCODER_TYPE) ?
-                new BcryptPasswordEncoder(bcryptStrength) :
-                new LegacyPasswordEncoder(legacySalt, legacyAlgorithm, true)
-        return encoder
-    }
-
-    private getPasswordType() {
-        return passwordEncoderType.equalsIgnoreCase(BCRYPT_ENCODER_TYPE) ? BCRYPT_ENCODER_TYPE : LEGACY_ENCODER_TYPE
     }
 }

--- a/userdetails-plugin/grails-app/services/au/org/ala/userdetails/PasswordService.groovy
+++ b/userdetails-plugin/grails-app/services/au/org/ala/userdetails/PasswordService.groovy
@@ -15,13 +15,13 @@
 
 package au.org.ala.userdetails
 
+import au.org.ala.auth.PasswordResetFailedException
 import au.org.ala.users.UserRecord
 import au.org.ala.auth.PasswordPolicy
 import au.org.ala.cas.encoding.BcryptPasswordEncoder
 import au.org.ala.cas.encoding.LegacyPasswordEncoder
 import au.org.ala.cas.encoding.PasswordEncoder
 import grails.core.GrailsApplication
-import grails.gorm.transactions.Transactional
 import org.apache.commons.lang3.RandomStringUtils
 import org.passay.CharacterCharacteristicsRule
 import org.passay.CharacterRule
@@ -41,7 +41,6 @@ import org.passay.dictionary.WordListDictionary
 import org.passay.dictionary.WordLists
 import org.passay.dictionary.sort.ArraysSort
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 
 
@@ -71,8 +70,24 @@ class PasswordService {
     String legacySalt
 
     @Autowired
-    @Qualifier('userService')
-    IUserService userService
+    IPasswordOperations passwordOperations
+
+    @Override
+    void resetAndSendTemporaryPassword(UserRecord user, String emailSubject, String emailTitle, String emailBody, String password) throws PasswordResetFailedException {
+        passwordOperations.resetAndSendTemporaryPassword(user, emailSubject, emailTitle, emailBody, password)
+    }
+
+    boolean resetPassword(UserRecord user, String newPassword, boolean isPermanent, String confirmationCode) {
+        return passwordOperations.resetPassword(user, newPassword, isPermanent, confirmationCode)
+    }
+
+    String getResetPasswordUrl(UserRecord user) {
+        return passwordOperations.getResetPasswordUrl(user)
+    }
+
+    String getPasswordResetView() {
+        return passwordOperations.getPasswordResetView()
+    }
 
     String generatePassword(UserRecord user) {
         if (user == null) {
@@ -80,7 +95,7 @@ class PasswordService {
         }
 
        def newPassword = generateNewPassword(user?.userName ?: user?.email ?: '')
-       userService.resetPassword(user, newPassword, false, null)
+       resetPassword(user, newPassword, false, null)
        return newPassword
     }
 

--- a/userdetails-plugin/grails-app/services/au/org/ala/userdetails/PasswordService.groovy
+++ b/userdetails-plugin/grails-app/services/au/org/ala/userdetails/PasswordService.groovy
@@ -72,7 +72,6 @@ class PasswordService {
     @Autowired
     IPasswordOperations passwordOperations
 
-    @Override
     void resetAndSendTemporaryPassword(UserRecord user, String emailSubject, String emailTitle, String emailBody, String password) throws PasswordResetFailedException {
         passwordOperations.resetAndSendTemporaryPassword(user, emailSubject, emailTitle, emailBody, password)
     }

--- a/userdetails-plugin/grails-app/views/registration/createAccount.gsp
+++ b/userdetails-plugin/grails-app/views/registration/createAccount.gsp
@@ -270,19 +270,21 @@
                             <g:link controller="Registration" action="disableMfa" params="[userId:user?.email]">Disable MFA</g:link>
                         </g:if>
                     </div>
-                    <div class="form-group">
-                        <label for="confirmUserPassword">
-                            <g:message code="create.account.confirm.password" />
-                        </label>
-                        <input id="confirmUserPassword"
-                               name="confirmUserPassword"
-                               class="form-control"
-                               value=""
-                               data-validation-engine="validate[required, minSize[8]]"
-                               data-errormessage-value-missing="Password is required!"
-                               type="password"
-                               autocomplete="current-password"/>
-                    </div>
+                    <g:if test="${grailsApplication.config.getProperty('userdetails.features.requirePasswordForUserUpdate', Boolean, true)}">
+                        <div class="form-group">
+                            <label for="confirmUserPassword">
+                                <g:message code="create.account.confirm.password" />
+                            </label>
+                            <input id="confirmUserPassword"
+                                   name="confirmUserPassword"
+                                   class="form-control"
+                                   value=""
+                                   data-validation-engine="validate[required, minSize[8]]"
+                                   data-errormessage-value-missing="Password is required!"
+                                   type="password"
+                                   autocomplete="current-password"/>
+                        </div>
+                    </g:if>
 
                     <button id="updateAccountSubmit" class="btn btn-primary"><g:message code="create.account.update.account" /></button>
                     <button id="disableAccountSubmit" class="btn btn-danger"><g:message code="create.account.disable.account" /></button>

--- a/userdetails-plugin/grails-app/views/registration/passwordResetCognito.gsp
+++ b/userdetails-plugin/grails-app/views/registration/passwordResetCognito.gsp
@@ -36,6 +36,9 @@
 <div class="row">
     <h1><g:message code="password.reset.description" /></h1>
 
+    <g:render template="passwordPolicy"
+              model="[passwordPolicy: passwordPolicy]"/>
+
     <g:hasErrors>
     <div class="alert alert-danger">
         <g:eachError var="err">

--- a/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/IPasswordOperations.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/IPasswordOperations.groovy
@@ -1,0 +1,27 @@
+package au.org.ala.userdetails
+
+import au.org.ala.auth.PasswordResetFailedException
+import au.org.ala.users.UserRecord
+
+/**
+ * Extracts operations used by the PasswordService into a provider
+ * specific class
+ */
+interface IPasswordOperations {
+
+    /**
+     * Resets a user's password
+     * @param user The user
+     * @param newPassword The new password
+     * @param isPermanent Whether this is a permanent or temporary reset
+     * @param confirmationCode The confirmation code provided by the user
+     * @return True if the password was reset, false otherwise
+     */
+    boolean resetPassword(UserRecord user, String newPassword, boolean isPermanent, String confirmationCode)
+
+    void resetAndSendTemporaryPassword(UserRecord user, String emailSubject, String emailTitle, String emailBody, String password) throws PasswordResetFailedException
+
+    String getResetPasswordUrl(UserRecord user)
+
+    String getPasswordResetView()
+}

--- a/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/IPasswordOperations.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/IPasswordOperations.groovy
@@ -24,4 +24,12 @@ interface IPasswordOperations {
     String getResetPasswordUrl(UserRecord user)
 
     String getPasswordResetView()
+
+    /**
+     * Check that a plain-text password matches a user's existing password.
+     * @param user The user.
+     * @param password The plain-text password to match.
+     * @return True if the password matches the existing password, otherwise false.
+     */
+    boolean checkUserPassword(UserRecord user, String password)
 }

--- a/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/IUserService.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/IUserService.groovy
@@ -16,14 +16,11 @@
 package au.org.ala.userdetails
 
 import au.org.ala.auth.BulkUserLoadResults
-import au.org.ala.auth.PasswordResetFailedException
 import au.org.ala.users.RoleRecord
 import au.org.ala.users.UserPropertyRecord
 import au.org.ala.users.UserRecord
 import au.org.ala.users.UserRoleRecord
 import grails.web.servlet.mvc.GrailsParameterMap
-
-import javax.servlet.http.HttpSession
 
 interface IUserService {
 
@@ -53,8 +50,6 @@ interface IUserService {
 
     void deleteUser(UserRecord user)
 
-    void resetAndSendTemporaryPassword(UserRecord user, String emailSubject, String emailTitle, String emailBody, String password) throws PasswordResetFailedException
-
     void clearTempAuthKey(UserRecord user)
 
     UserRecord getUserById(String userId)
@@ -65,8 +60,6 @@ interface IUserService {
      * This service method returns the UserRecord object for the current user.
      */
     UserRecord getCurrentUser()
-
-    String getResetPasswordUrl(UserRecord user)
 
     Collection<UserRecord> findUsersForExport(List usersInRoles, includeInactive)
 
@@ -172,10 +165,6 @@ interface IUserService {
     List<String[]> listIdsAndNames()
 
     List<String[]> listUserDetails()
-
-    boolean resetPassword(UserRecord user, String newPassword, boolean isPermanent, String confirmationCode)
-
-    String getPasswordResetView()
 
     def sendAccountActivation(UserRecord user)
 

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/AuthorisedSystem.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/AuthorisedSystem.groovy
@@ -18,8 +18,7 @@ package au.org.ala.users
 import grails.web.databinding.WebDataBinding
 import groovy.transform.EqualsAndHashCode
 
-@EqualsAndHashCode()
-//@EqualsAndHashCode(includes = 'id')
+@EqualsAndHashCode
 class AuthorisedSystem implements WebDataBinding, Serializable {
 
     String host

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/UserPropertyRecord.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/UserPropertyRecord.groovy
@@ -19,9 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import grails.web.databinding.WebDataBinding
 import groovy.transform.EqualsAndHashCode
 
-//@Entity
-//@EqualsAndHashCode(includes = 'id')
-@EqualsAndHashCode()
+@EqualsAndHashCode
 @JsonIgnoreProperties(['metaClass','errors'])
 class UserPropertyRecord implements WebDataBinding, Serializable {
 

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRecord.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRecord.groovy
@@ -25,14 +25,7 @@ import java.sql.Timestamp
 //@EqualsAndHashCode(includes = 'id')
 class UserRecord<T> implements WebDataBinding, Serializable {
 
-    static hasMany =  [
-            userRoles: UserRoleRecord,
-            userProperties: UserPropertyRecord
-    ]
-
     T id
-
-    String userId
 
     String firstName
     String lastName
@@ -50,8 +43,6 @@ class UserRecord<T> implements WebDataBinding, Serializable {
 
     String tempAuthKey
 
-    String displayName
-
     Collection<UserRoleRecord> userRoles
     Collection<UserPropertyRecord> userProperties
 
@@ -63,41 +54,11 @@ class UserRecord<T> implements WebDataBinding, Serializable {
         locked nullable: false
         lastLogin nullable: true
         tempAuthKey nullable: true
-        displayName nullable: true
     }
 
-//    static List<String[]> findNameAndEmailWhereEmailIsNotNull() {
-//        return UserRecord.withCriteria {
-//            isNotNull('email')
-//            projections {
-//                property('email')
-//                property('firstName')
-//                property('lastName')
-//            }
-//        }
-//    }
-//
-//    static List<String[]> findIdFirstAndLastName() {
-//        return UserRecord.withCriteria {
-//            projections {
-//                property('id')
-//                property('firstName')
-//                property('lastName')
-//            }
-//        }
-//    }
-//
-//    static List<String[]> findUserDetails() {
-//        return UserRecord.withCriteria {
-//            projections {
-//                property('id')
-//                property('firstName')
-//                property('lastName')
-//                property('userName')
-//                property('email')
-//            }
-//        }
-//    }
+    String getUserId() {
+        return this.userName
+    }
 
     def propsAsMap(){
         def map = [:]

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRecord.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRecord.groovy
@@ -21,8 +21,7 @@ import groovy.transform.EqualsAndHashCode
 
 import java.sql.Timestamp
 
-@EqualsAndHashCode()
-//@EqualsAndHashCode(includes = 'id')
+@EqualsAndHashCode
 class UserRecord<T> implements WebDataBinding, Serializable {
 
     T id

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRoleRecord.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRoleRecord.groovy
@@ -19,9 +19,7 @@ package au.org.ala.users
 import grails.web.databinding.WebDataBinding
 import groovy.transform.EqualsAndHashCode
 
-//@Entity
-@EqualsAndHashCode()
-//@EqualsAndHashCode(includes = 'id')
+@EqualsAndHashCode
 class UserRoleRecord implements WebDataBinding, Serializable {
 
     UserRecord user

--- a/userdetails-plugin/src/test/groovy/au/org/ala/userdetails/RegistrationControllerSpec.groovy
+++ b/userdetails-plugin/src/test/groovy/au/org/ala/userdetails/RegistrationControllerSpec.groovy
@@ -194,7 +194,7 @@ class RegistrationControllerSpec extends UserDetailsSpec implements ControllerUn
         controller.updatePassword()
 
         then:
-        1 * userService.resetPassword(user, password, _, _)
+        1 * passwordService.resetPassword(user, password, _, _)
         1 * passwordService.validatePassword(user.email, password) >> new RuleResult(true)
         1 * passwordService.resetPassword(user, password)
         1 * userService.clearTempAuthKey(user)
@@ -238,7 +238,7 @@ class RegistrationControllerSpec extends UserDetailsSpec implements ControllerUn
         1 * userService.isEmailRegistered(email) >> false
         1 * passwordService.validatePassword(email, password) >> new RuleResult(true)
         1 * userService.registerUser(_) >> { def user = new UserRecord(params); user.tempAuthKey = authKey; user }
-        1 * userService.resetPassword(_, password, _, _)
+        1 * passwordService.resetPassword(_, password, _, _)
         1 * emailService.sendAccountActivation(_, authKey)
         0 * _ // no other interactions
         response.redirectedUrl == '/registration/accountCreated'
@@ -312,7 +312,7 @@ class RegistrationControllerSpec extends UserDetailsSpec implements ControllerUn
         then:
         1 * recaptchaClient.verify(secretKey, null, '127.0.0.1') >> { Calls.response(new RecaptchaResponse(false, null, null, ['missing-input-response'])) }
         0 * userService.registerUser(_)
-        0 * userService.resetPassword(_, _, _, _)
+        0 * passwordService.resetPassword(_, _, _, _)
         0 * emailService.sendAccountActivation(_, _)
         0 * _ // no other interactions
         view == '/registration/createAccount'

--- a/userdetails-plugin/src/test/groovy/au/org/ala/userdetails/UserDetailsSpec.groovy
+++ b/userdetails-plugin/src/test/groovy/au/org/ala/userdetails/UserDetailsSpec.groovy
@@ -73,7 +73,7 @@ abstract class UserDetailsSpec extends Specification {
         role.save(failOnError: true, flush: true)
 
 
-        UserRecord user = new UserRecord(userId:"test first", firstName: 'test first', lastName: 'test last', email: 'test@test.com', userName:'test@test.com', activated: true, locked: false, tempAuthKey: tempAuthKey)
+        UserRecord user = new UserRecord(firstName: 'test first', lastName: 'test last', email: 'test@test.com', userName:'test@test.com', activated: true, locked: false, tempAuthKey: tempAuthKey)
         user.save(failOnError: true, flush: true)
 
         UserRoleRecord userRole = new UserRoleRecord(user:user, role:role)


### PR DESCRIPTION
- Extract password operations from IUserService to IPasswordOperations to fix circular dependency between PasswordService and UserService
- Fix GORM saving userId by changing userId to a read only property on UserRecord
- Remove @EqualsAndHashCode from domain classes
- Remove displayName from base UserRecord as it's unused
-  Add password policy to model of createAccount and resetPassword views
 - Add separate userdetails external config files for gorm and congito for easier development switching
 - Clean up some dependencies