### PR TITLE
Fix loading of GORM associations

### DIFF
--- a/userdetails-cognito/src/main/groovy/au/org/ala/userdetails/CognitoUserService.groovy
+++ b/userdetails-cognito/src/main/groovy/au/org/ala/userdetails/CognitoUserService.groovy
@@ -54,7 +54,7 @@ import org.springframework.beans.factory.annotation.Value
 import java.util.stream.Stream
 
 @Slf4j
-class CognitoUserService implements IUserService {
+class CognitoUserService implements IUserService<UserRecord, UserPropertyRecord, RoleRecord, UserRoleRecord> {
 
     static mainAttrs = ['given_name', 'family_name', 'email', 'username', 'roles'] as Set
 
@@ -71,6 +71,15 @@ class CognitoUserService implements IUserService {
     @Value('${attributes.affiliations.enabled:false}')
     boolean affiliationsEnabled = false
     public static final String TEMP_AUTH_KEY = 'tempAuthKey'
+
+    @Override
+    UserRecord newUser(GrailsParameterMap params) {
+        return params ? new UserRecord(params) : new UserRecord()
+    }
+
+    RoleRecord newRole(GrailsParameterMap params) {
+        return params ? new RoleRecord(role: params.role, description: params.description) : new RoleRecord()
+    }
 
     @Override
     boolean updateUser(String userId, GrailsParameterMap params) {

--- a/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/Password.groovy
+++ b/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/Password.groovy
@@ -51,4 +51,23 @@ class Password implements Serializable {
         status nullable: false, blank: false
         expiry nullable: true
     }
+
+    boolean equals(o) {
+        if (this.is(o)) return true
+        if (o == null || getClass() != o.class) return false
+
+        Password password1 = (Password) o
+
+        if (password != password1.password) return false
+        if (user != password1.user) return false
+
+        return true
+    }
+
+    int hashCode() {
+        int result
+        result = password.hashCode()
+        result = 31 * result + (user != null ? user.hashCode() : 0)
+        return result
+    }
 }

--- a/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/Role.groovy
+++ b/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/Role.groovy
@@ -15,9 +15,9 @@
 
 package au.org.ala.userdetails.gorm
 
-import au.org.ala.users.RoleRecord
+import au.org.ala.users.IRole
 
-class Role extends RoleRecord implements Serializable {
+class Role implements IRole, Serializable {
 
     String role
     String description
@@ -34,5 +34,20 @@ class Role extends RoleRecord implements Serializable {
     static constraints = {
         role nullable: false, blank: false
         description nullable:true
+    }
+
+    boolean equals(o) {
+        if (this.is(o)) return true
+        if (o == null || getClass() != o.class) return false
+
+        Role role1 = (Role) o
+
+        if (role != role1.role) return false
+
+        return true
+    }
+
+    int hashCode() {
+        return (role != null ? role.hashCode() : 0)
     }
 }

--- a/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/UserProperty.groovy
+++ b/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/UserProperty.groovy
@@ -15,17 +15,19 @@
 
 package au.org.ala.userdetails.gorm
 
-import au.org.ala.users.UserPropertyRecord
+import au.org.ala.users.IUserProperty
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import groovy.transform.EqualsAndHashCode
 
-@JsonIgnoreProperties(['metaClass','errors'])
-class UserProperty extends UserPropertyRecord implements Serializable {
+@JsonIgnoreProperties(['metaClass','errors','owner'])
+class UserProperty implements IUserProperty<User>, Serializable {
 
     User user
     String name
     String value
-    String id
+
+    static belongsTo = [user: User]
+
+    static transients = ['owner']
 
     static def addOrUpdateProperty(user, name, value){
 
@@ -41,6 +43,7 @@ class UserProperty extends UserPropertyRecord implements Serializable {
 
     static mapping = {
         table 'profiles'
+//        tablePerSubclass false
         id composite: ['user', 'name']
         user column:  'userid'
         name column: 'property'
@@ -76,4 +79,10 @@ class UserProperty extends UserPropertyRecord implements Serializable {
         result = 31 * result + (value != null ? value.hashCode() : 0)
         return result
     }
+
+    @Override
+    User getOwner() {
+        return this.user
+    }
+
 }

--- a/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/UserRole.groovy
+++ b/userdetails-gorm/grails-app/domain/au/org/ala/userdetails/gorm/UserRole.groovy
@@ -15,13 +15,16 @@
 
 package au.org.ala.userdetails.gorm
 
-import au.org.ala.users.UserRoleRecord
+import au.org.ala.users.IUserRole
 import groovy.transform.EqualsAndHashCode
 
-class UserRole extends UserRoleRecord implements Serializable {
+@EqualsAndHashCode(includes = ['user', 'role'])
+class UserRole implements IUserRole<User, Role>, Serializable {
 
     User user
     Role role
+
+    static transients = ['owner', 'roleObject']
 
     static mapping = {
         id composite: ['user', 'role']
@@ -34,4 +37,13 @@ class UserRole extends UserRoleRecord implements Serializable {
         role
     }
 
+    @Override
+    User getOwner() {
+        return user
+    }
+
+    @Override
+    Role getRoleObject() {
+        return role
+    }
 }

--- a/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/AdminController.groovy
+++ b/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/AdminController.groovy
@@ -16,6 +16,7 @@
 package au.org.ala.userdetails
 
 import au.org.ala.auth.PreAuthorise
+import au.org.ala.users.IUser
 import au.org.ala.users.RoleRecord
 import au.org.ala.users.UserRecord
 import com.opencsv.CSVWriterBuilder
@@ -97,7 +98,7 @@ class AdminController {
                 secondaryFields.each {
                     formatters[it] = { domain, value ->
                         String fieldName = it
-                        domain.userProperties.find {
+                        domain.additionalAttributes.find {
                             it.name == fieldName
                         }?.value
                     }
@@ -106,10 +107,10 @@ class AdminController {
 
             if (params.includeRoles) {
                 String roleFieldName = 'roles'
-                formatters[roleFieldName] = { UserRecord domain, value ->
+                formatters[roleFieldName] = { IUser domain, value ->
                     def result = ""
-                    domain.userRoles.each {
-                        result += it.role.role + " "
+                    domain.roles.each {
+                        result += it.roleObject.role + " "
                     }
                     result
                 }

--- a/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/ExternalSiteController.groovy
+++ b/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/ExternalSiteController.groovy
@@ -63,9 +63,9 @@ class ExternalSiteController {
         def flickrIds = userService.searchProperty(null, "flickrId")
         render(contentType: "application/json") {
             flickrUsers(flickrIds) { UserPropertyRecord flickrId ->
-                id flickrId.user.id.toString()
+                id flickrId.owner.id.toString()
                 externalId flickrId.value
-                externalUsername flickrId.user.userProperties.find { it.name == 'flickrUsername' }?.value
+                externalUsername flickrId.owner.additionalAttributes.find { it.name == 'flickrUsername' }?.value
                 externalUrl 'http://www.flickr.com/photos/' + flickrId.value
             }
         }

--- a/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/RoleController.groovy
+++ b/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/RoleController.groovy
@@ -50,7 +50,7 @@ class RoleController {
         def pattern = ~/[A-Z_]{1,}/
 
         if(pattern.matcher(params.role).matches()){
-            def roleInstance = new RoleRecord(role: params.role, description: params.description)
+            def roleInstance = userService.newRole(params)//new RoleRecord(role: params.role, description: params.description)
             def saved = userService.addRole(roleInstance) // roleInstance.save(flush: true)
             if (!saved) {
                 render(view: "create", model: [roleInstance: roleInstance])

--- a/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/UserController.groovy
+++ b/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/UserController.groovy
@@ -58,7 +58,7 @@ class UserController {
     }
 
     def create() {
-        [userInstance: new UserRecord(params)]
+        [userInstance: userService.newUser(params)]
     }
 
     @Transactional
@@ -66,7 +66,7 @@ class UserController {
         UserRecord user = userService.registerUser(params)
 
         if (!user) {
-            render(view: "create", model: [userInstance: new UserRecord()])
+            render(view: "create", model: [userInstance: userService.newUser(params)])
             return
         }
         userService.sendAccountActivation(user)

--- a/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/UserRoleController.groovy
+++ b/userdetails-plugin/grails-app/controllers/au/org/ala/userdetails/UserRoleController.groovy
@@ -16,8 +16,8 @@
 package au.org.ala.userdetails
 
 import au.org.ala.auth.PreAuthorise
-import au.org.ala.users.UserRecord
-import au.org.ala.users.UserRoleRecord
+import au.org.ala.users.IUser
+import au.org.ala.users.IUserRole
 import grails.converters.JSON
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
@@ -37,15 +37,15 @@ class UserRoleController {
 
     def create() {
 
-        UserRecord user = userService.getUserById(params['user.id'])
+        IUser user = userService.getUserById(params['user.id'])
 
         def roles = userService.listRoles()
 
         //remove existing roles this user has
-        def usersRoles = user.getUserRoles()
+        def usersRoles = user.roles
 
         def acquiredRoles = []
-        usersRoles.each { acquiredRoles << it.role}
+        usersRoles.each { acquiredRoles << it.roleObject }
 
         roles.removeAll(acquiredRoles)
 
@@ -54,7 +54,7 @@ class UserRoleController {
 
     def list() {
 
-        PagedResult<UserRoleRecord> model = userService.findUserRoles(params.role, params)
+        PagedResult<IUserRole> model = userService.findUserRoles(params.role, params)
 //        if(params.role){
 //            def role = userService.findUserRoles(params.role, params) // RoleRecord.findByRole(params.role)
 //            if(role){

--- a/userdetails-plugin/grails-app/services/au/org/ala/userdetails/ProfileService.groovy
+++ b/userdetails-plugin/grails-app/services/au/org/ala/userdetails/ProfileService.groovy
@@ -15,8 +15,9 @@
 
 package au.org.ala.userdetails
 
+import au.org.ala.users.IUser
+import au.org.ala.users.IUserProperty
 import au.org.ala.users.UserRecord
-import au.org.ala.users.UserPropertyRecord
 import org.springframework.beans.factory.annotation.Autowired
 
 class ProfileService {
@@ -24,15 +25,15 @@ class ProfileService {
     @Autowired
     IUserService userService
 
-    List<UserPropertyRecord> getUserProperty(UserRecord user, String name) {
+    List<? extends IUserProperty> getUserProperty(IUser user, String name) {
         userService.searchProperty(user, name)
     }
 
-    UserPropertyRecord saveUserProperty(UserRecord user, String name, String value) {
+    IUserProperty saveUserProperty(IUser user, String name, String value) {
         userService.addOrUpdateProperty(user, name, value);
     }
 
-    List<UserPropertyRecord> getAllAvailableProperties() {
+    List<? extends IUserProperty> getAllAvailableProperties() {
         userService.searchProperty(null, null)
     }
 }

--- a/userdetails-plugin/grails-app/views/user/show.gsp
+++ b/userdetails-plugin/grails-app/views/user/show.gsp
@@ -116,9 +116,9 @@
             </li>
         </g:if>
 
-        <g:if test="${userInstance?.userProperties}">
+        <g:if test="${userInstance?.additionalAttributes}">
 
-                <g:each in="${userInstance.userProperties}" var="u">
+                <g:each in="${userInstance.additionalAttributes}" var="u">
                                 <li class="fieldcontain">
 
                     <span id="userProperties-label" class="property-label">${u.name}</span>
@@ -149,8 +149,8 @@
         <h4><g:message code="user.userRoles.label"
                                                                              default="Roles"/></h4>
         <br/>
-        <g:if test="${userInstance?.userRoles}">
-                <g:each in="${userInstance.userRoles}" var="u">
+        <g:if test="${userInstance?.roles}">
+                <g:each in="${userInstance.roles}" var="u">
                     <span class="property-value" aria-labelledby="userRoles-label">
                         <g:link controller="userRole" action="list" params="[role:u?.encodeAsHTML()]">${u?.encodeAsHTML()}</g:link>
                     </span>

--- a/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/IUserService.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/IUserService.groovy
@@ -16,19 +16,31 @@
 package au.org.ala.userdetails
 
 import au.org.ala.auth.BulkUserLoadResults
+import au.org.ala.users.IRole
+import au.org.ala.users.IUser
+import au.org.ala.users.IUserProperty
+import au.org.ala.users.IUserRole
 import au.org.ala.users.RoleRecord
 import au.org.ala.users.UserPropertyRecord
 import au.org.ala.users.UserRecord
 import au.org.ala.users.UserRoleRecord
 import grails.web.servlet.mvc.GrailsParameterMap
 
-interface IUserService {
+interface IUserService<U extends IUser<? extends Serializable>, P extends IUserProperty<U>, R extends IRole, UR extends IUserRole<U, R>> {
+
+    //
+
+    U newUser(GrailsParameterMap params)
+    R newRole(GrailsParameterMap params)
+//    UserPropertyRecord newProperty(GrailsParameterMap params)
+//    UserRoleRecord newRole(GrailsParameterMap params)
+
 
     //    *********** User related services *************
 
     boolean updateUser(String userId, GrailsParameterMap params)
 
-    boolean disableUser(UserRecord user)
+    boolean disableUser(U user)
 
     boolean isActive(String email)
 
@@ -36,30 +48,30 @@ interface IUserService {
 
     boolean isEmailInUse(String newEmail)
 
-    boolean activateAccount(UserRecord user, GrailsParameterMap params)
+    boolean activateAccount(U user, GrailsParameterMap params)
 
-    List<UserRecord> listUsers(String query, String paginationToken, int maxResults)
+    List<U> listUsers(String query, String paginationToken, int maxResults)
 
-    Collection<UserRecord> listUsers()
+    Collection<U> listUsers()
 
     BulkUserLoadResults bulkRegisterUsersFromFile(InputStream stream, Boolean firstRowContainsFieldNames, String affiliation, String emailSubject, String emailTitle, String emailBody)
 
-    UserRecord registerUser(GrailsParameterMap params) throws Exception
+    U registerUser(GrailsParameterMap params) throws Exception
 
-    void updateProperties(UserRecord user, GrailsParameterMap params)
+    void updateProperties(U user, GrailsParameterMap params)
 
-    void deleteUser(UserRecord user)
+    void deleteUser(U user)
 
-    UserRecord getUserById(String userId)
+    U getUserById(String userId)
 
-    UserRecord getUserByEmail(String email)
+    U getUserByEmail(String email)
 
     /**
      * This service method returns the UserRecord object for the current user.
      */
-    UserRecord getCurrentUser()
+    U getCurrentUser()
 
-    Collection<UserRecord> findUsersForExport(List usersInRoles, includeInactive)
+    Collection<U> findUsersForExport(List usersInRoles, includeInactive)
 
     /**
      * Calculate the number of active users (not locked and is activated), as well as the number
@@ -77,7 +89,7 @@ interface IUserService {
 
     def getUserDetailsFromIdList(List idList)
 
-    UserRecord findByUserNameOrEmail(String username)
+    U findByUserNameOrEmail(String username)
 
     List<String[]> listNamesAndEmails()
 
@@ -87,7 +99,7 @@ interface IUserService {
 
     //    *********** Role services *************
 
-    Collection<RoleRecord> listRoles()
+    Collection<R> listRoles()
 
     /**
      * Retrieve a list of roles, paged by the params in the argument.
@@ -104,7 +116,7 @@ interface IUserService {
      * @param params The parameters that may be used in the search
      * @return A result with the list of roles and either the total count or the next page token.
      */
-    PagedResult<RoleRecord> listRoles(GrailsParameterMap params)
+    PagedResult<R> listRoles(GrailsParameterMap params)
 
     /**
      * Add a role with `rolename` to user identified by `userid`
@@ -129,7 +141,7 @@ interface IUserService {
      *
      * @param roleRecords The list of RoleRecords to add
      */
-    void addRoles(Collection<RoleRecord> roleRecords)
+    void addRoles(Collection<R> roleRecords)
 
     /**
      * Add a single role to the system.
@@ -137,7 +149,7 @@ interface IUserService {
      * @param roleRecord The RoleRecord to add
      */
 
-    RoleRecord addRole(RoleRecord roleRecord)
+    R addRole(R roleRecord)
 
     /**
      * Find a list of users for a given role.
@@ -154,13 +166,13 @@ interface IUserService {
      * @param role The role name to get the list of users for
      * @param params The paging parameters for the request
      */
-    PagedResult<UserRoleRecord> findUserRoles(String role, GrailsParameterMap params)
+    PagedResult<UR> findUserRoles(String role, GrailsParameterMap params)
 
     //    *********** account related services *************
 
-    void clearTempAuthKey(UserRecord user)
+    void clearTempAuthKey(U user)
 
-    def sendAccountActivation(UserRecord user)
+    def sendAccountActivation(U user)
 
     //    *********** MFA services *************
 
@@ -172,9 +184,9 @@ interface IUserService {
 
 //    *********** Property related services *************
 
-    UserPropertyRecord addOrUpdateProperty(UserRecord userRecord, String name, String value)
+    P addOrUpdateProperty(U userRecord, String name, String value)
 
-    void removeUserProperty(UserRecord userRecord, ArrayList<String> attributes)
+    void removeUserProperty(U userRecord, ArrayList<String> attributes)
 
-    List<UserPropertyRecord> searchProperty(UserRecord userRecord, String attribute)
+    List<P> searchProperty(U userRecord, String attribute)
 }

--- a/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/marshaller/UserMarshaller.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/userdetails/marshaller/UserMarshaller.groovy
@@ -15,7 +15,7 @@
 
 package au.org.ala.userdetails.marshaller
 
-
+import au.org.ala.users.IUser
 import au.org.ala.users.UserRecord
 import grails.converters.JSON
 
@@ -26,7 +26,7 @@ class UserMarshaller {
 
     public static final String WITH_PROPERTIES_CONFIG = 'withProperties'
 
-    private Map toMap(UserRecord user) {
+    private Map toMap(IUser user) {
         [
                 userId: user.id?.toString(),
                 userName: user.userName,
@@ -35,21 +35,21 @@ class UserMarshaller {
                 email: user.email,
                 activated: user.activated,
                 locked: user.locked,
-                roles: user.getUserRoles()*.toString() ?: []
+                roles: user.roles*.roleObject*.role ?: []
         ]
     }
 
     void register(){
 
         JSON.createNamedConfig(WITH_PROPERTIES_CONFIG) {
-            it.registerObjectMarshaller(UserRecord) { UserRecord user ->
+            it.registerObjectMarshaller(IUser) { IUser user ->
                 Map userMap = toMap(user)
-                userMap.props = user.userProperties.collectEntries { [(it.name): it.value] }
+                userMap.props = user.additionalAttributes.collectEntries { [(it.name): it.value] }
 
                 userMap
             }
         }
-        JSON.registerObjectMarshaller(UserRecord) { UserRecord user ->
+        JSON.registerObjectMarshaller(IUser) { IUser user ->
             toMap(user)
         }
     }

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/IRole.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/IRole.groovy
@@ -1,0 +1,14 @@
+package au.org.ala.users
+
+/**
+ * Read only view of a role object
+ */
+interface IRole {
+
+    String getRole()
+    String getDescription()
+
+    default String toString() {
+        return role
+    }
+}

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/IUser.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/IUser.groovy
@@ -1,0 +1,50 @@
+package au.org.ala.users
+
+import java.sql.Timestamp
+
+/**
+ * Read only view of a User object that can be implemented by various backends
+ * @param <T> The type of the id field
+ */
+interface IUser<T extends Serializable> {
+
+    T getId()
+
+    String getUserId()
+
+    String getFirstName()
+    String getLastName()
+
+    String getUserName()
+    String getEmail()
+
+    Date getDateCreated()
+    Date getLastUpdated()
+
+    Timestamp getLastLogin()
+
+    Boolean getActivated()
+    Boolean getLocked()
+
+    String getTempAuthKey()
+
+    /**
+     * Associated roles property.  This is named differently to the original GORM implementations fields due to the
+     * way GORM discovers associated properties.
+     * @return
+     */
+    Set<? extends IUserRole<? extends IUser<? extends Serializable>, ? extends IRole>> getRoles()
+
+    /**
+     * Associated additional attributes property.  This is named differently to the original GORM implementations fields due to the
+     * way GORM discovers associated properties.
+     * @return
+     */
+    Set<? extends IUserProperty<? extends IUser<? extends Serializable>>> getAdditionalAttributes()
+
+    def propsAsMap()
+
+    default String toString(){
+        return "${firstName} ${lastName} <${email}>"
+    }
+}

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/IUserProperty.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/IUserProperty.groovy
@@ -1,0 +1,22 @@
+package au.org.ala.users
+
+/**
+ * Read only view of a user's single additional attribute
+ * @param <U>
+ */
+interface IUserProperty<U extends IUser<? extends Serializable>> {
+
+    /**
+     * Associated user property.  This is named differently to the original GORM implementations fields due to the
+     * way GORM discovers associated properties.
+     * @return
+     */
+    U getOwner()
+    String getName()
+    String getValue()
+
+    default String toString() {
+        return "${name}:${value}"
+    }
+
+}

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/IUserRole.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/IUserRole.groovy
@@ -1,0 +1,24 @@
+package au.org.ala.users
+
+/**
+ * Read only view of a user to role mapping.
+ */
+interface IUserRole<U extends IUser<? extends Serializable>, R extends IRole> {
+
+    /**
+     * Associated user property.  This is named differently to the original GORM implementations fields due to the
+     * way GORM discovers associated properties.
+     * @return
+     */
+    U getOwner()
+    /**
+     * Associated user property.  This is named differently to the original GORM implementations fields due to the
+     * way GORM discovers associated properties.
+     * @return
+     */
+    R getRoleObject()
+
+    default String toString() {
+        return roleObject.role
+    }
+}

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/RoleRecord.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/RoleRecord.groovy
@@ -15,7 +15,7 @@
 
 package au.org.ala.users
 
-class RoleRecord implements Serializable {
+class RoleRecord implements IRole, Serializable {
 
     String role
     String description

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/UserPropertyRecord.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/UserPropertyRecord.groovy
@@ -21,7 +21,7 @@ import groovy.transform.EqualsAndHashCode
 
 @EqualsAndHashCode
 @JsonIgnoreProperties(['metaClass','errors'])
-class UserPropertyRecord implements WebDataBinding, Serializable {
+class UserPropertyRecord implements IUserProperty<UserRecord>, WebDataBinding, Serializable {
 
     UserRecord user
     String name
@@ -34,5 +34,10 @@ class UserPropertyRecord implements WebDataBinding, Serializable {
 
     String toString(){
         name + " : " + value
+    }
+
+    @Override
+    UserRecord getOwner() {
+        return user
     }
 }

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRecord.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRecord.groovy
@@ -21,10 +21,13 @@ import groovy.transform.EqualsAndHashCode
 
 import java.sql.Timestamp
 
+/**
+ * Implementation of IUser as a simple POJO
+ */
 @EqualsAndHashCode
-class UserRecord<T> implements WebDataBinding, Serializable {
+class UserRecord implements IUser<String>, WebDataBinding, Serializable {
 
-    T id
+    String id
 
     String firstName
     String lastName
@@ -42,8 +45,8 @@ class UserRecord<T> implements WebDataBinding, Serializable {
 
     String tempAuthKey
 
-    Collection<UserRoleRecord> userRoles
-    Collection<UserPropertyRecord> userProperties
+    Set<UserRoleRecord> userRoles
+    Set<UserPropertyRecord> userProperties
 
     static constraints = {
         email nullable: true
@@ -69,5 +72,15 @@ class UserRecord<T> implements WebDataBinding, Serializable {
 
     String toString(){
         firstName + " " + lastName + " <" +email +">"
+    }
+
+    @Override
+    Set<UserRoleRecord> getRoles() {
+        return userRoles
+    }
+
+    @Override
+    Set<UserPropertyRecord> getAdditionalAttributes() {
+        return userProperties
     }
 }

--- a/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRoleRecord.groovy
+++ b/userdetails-plugin/src/main/groovy/au/org/ala/users/UserRoleRecord.groovy
@@ -20,7 +20,7 @@ import grails.web.databinding.WebDataBinding
 import groovy.transform.EqualsAndHashCode
 
 @EqualsAndHashCode
-class UserRoleRecord implements WebDataBinding, Serializable {
+class UserRoleRecord implements IUserRole<UserRecord, RoleRecord>, WebDataBinding, Serializable {
 
     UserRecord user
     RoleRecord role
@@ -31,4 +31,13 @@ class UserRoleRecord implements WebDataBinding, Serializable {
         role
     }
 
+    @Override
+    UserRecord getOwner() {
+        return user
+    }
+
+    @Override
+    RoleRecord getRoleObject() {
+        return role
+    }
 }


### PR DESCRIPTION
 - Create read only interfaces for core domain classes
   - This allows the GORM classes to not contain overridden fields from super classes
   - Rename properties that were originally GORM associations.  Overriding associations made GORM ignore the intended relationships between classes because the association property would have multiple mutators or the mutator and accessor types would not match.
 - Rework IUserService to be generic and return generic versions, this allows Gorm and Cognito services to return concrete implementations