### PR TITLE
fix symbol character set used in temporary password generation

### DIFF
--- a/grails-app/services/au/org/ala/userdetails/PasswordService.groovy
+++ b/grails-app/services/au/org/ala/userdetails/PasswordService.groovy
@@ -15,6 +15,7 @@
 
 package au.org.ala.userdetails
 
+import au.org.ala.auth.EnglishCustomCharacterData
 import au.org.ala.auth.PasswordPolicy
 import au.org.ala.cas.encoding.BcryptPasswordEncoder
 import au.org.ala.cas.encoding.LegacyPasswordEncoder
@@ -282,7 +283,7 @@ class PasswordService {
                     ruleGroup.rules.add(new CharacterRule(EnglishCharacterData.Digit, policy.charGroupMinDigit))
                 }
                 if (policy.charGroupMinSpecial > 0) {
-                    ruleGroup.rules.add(new CharacterRule(EnglishCharacterData.Special, policy.charGroupMinSpecial))
+                    ruleGroup.rules.add(new CharacterRule(EnglishCustomCharacterData.Special, policy.charGroupMinSpecial))
                 }
             }
 


### PR DESCRIPTION
use custom character data for symbols (without extra special characters)